### PR TITLE
feat: Added tokens for Badge

### DIFF
--- a/tokens/blocket.se/badge.yml
+++ b/tokens/blocket.se/badge.yml
@@ -1,0 +1,29 @@
+---
+token: maps
+
+color:
+  box:
+    neutral:
+      text: bluegray-900
+      background: gray-100
+    info:
+      text: aqua-900
+      background: aqua-100
+    positive:
+      text: green-900
+      background: green-100
+    warning:
+      text: yellow-900
+      background: yellow-100
+    negative:
+      text: red-900
+      background: red-100
+    disabled:
+      text: bluegray-900
+      background: bluegray-300
+    price:
+      text: white
+      background: gray-900
+    notification:
+      text: white
+      background: red-600

--- a/tokens/finn.no/badge.yml
+++ b/tokens/finn.no/badge.yml
@@ -1,0 +1,29 @@
+---
+token: maps
+
+color:
+  box:
+    neutral:
+      text: bluegray-900
+      background: gray-100
+    info:
+      text: aqua-900
+      background: aqua-100
+    positive:
+      text: green-900
+      background: green-100
+    warning:
+      text: yellow-900
+      background: yellow-100
+    negative:
+      text: red-900
+      background: red-100
+    disabled:
+      text: bluegray-900
+      background: bluegray-300
+    price:
+      text: white
+      background: gray-900
+    notification:
+      text: white
+      background: red-600

--- a/tokens/tori.fi/badge.yml
+++ b/tokens/tori.fi/badge.yml
@@ -1,0 +1,29 @@
+---
+token: maps
+
+color:
+  box:
+    neutral:
+      text: bluegray-900
+      background: gray-100
+    info:
+      text: aqua-900
+      background: aqua-100
+    positive:
+      text: green-900
+      background: green-100
+    warning:
+      text: yellow-900
+      background: yellow-100
+    negative:
+      text: red-900
+      background: red-100
+    disabled:
+      text: bluegray-900
+      background: bluegray-300
+    price:
+      text: white
+      background: gray-900
+    notification:
+      text: white
+      background: red-600


### PR DESCRIPTION
`color-badge-price-background` should have a value of `gray-900 (70% opacity)`, but I'm not sure how to handle this kind of opacity. Is it done somewhere already? Or what should we do about these kind of values? 🤔 

There are no values for Tori in the tokens sheet, so they are just a copy of Finn for now.