### PR TITLE
fix: update buttongroup tokens to utility & primary

### DIFF
--- a/tokens/blocket.se/buttongroup.yml
+++ b/tokens/blocket.se/buttongroup.yml
@@ -3,19 +3,34 @@ token: maps
 
 color:
   buttongroup:
-    text:
-      _: blue-600
-      active: white
-    background:
-      _: white
-      hover: blue-50
-      active:
+    primary:
+      text:
         _: blue-600
-        hover: blue-700
-    border:
-      _: bluegray-300
-      hover: blue-600
-      active: blue-600
+        active: white
+      background:
+        _: white
+        hover: blue-50
+        active:
+          _: blue-600
+          hover: blue-700
+      border:
+        _: bluegray-300
+        hover: blue-600
+        active: blue-600
+    utility:
+      text:
+        _: gray-700
+        active: gray-700
+      background:
+        _: white
+        hover: gray-100
+        active:
+          _: gray-200
+          hover: gray-200
+      border:
+        _: gray-300
+        hover: gray-500
+        active: gray-700
 shadow:
   buttongroup:
     _: shadow-small

--- a/tokens/finn.no/buttongroup.yml
+++ b/tokens/finn.no/buttongroup.yml
@@ -3,19 +3,34 @@ token: maps
 
 color:
   buttongroup:
-    text:
-      _: blue-600
-      active: white
-    background:
-      _: white
-      hover: blue-50
-      active:
+    primary:
+      text:
         _: blue-600
-        hover: blue-700
-    border:
-      _: bluegray-300
-      hover: blue-600
-      active: blue-600
+        active: white
+      background:
+        _: white
+        hover: blue-50
+        active:
+          _: blue-600
+          hover: blue-700
+      border:
+        _: bluegray-300
+        hover: blue-600
+        active: blue-600
+    utility:
+      text:
+        _: gray-700
+        active: gray-700
+      background:
+        _: white
+        hover: gray-100
+        active:
+          _: gray-200
+          hover: gray-200
+      border:
+        _: gray-300
+        hover: gray-500
+        active: gray-700
 shadow:
   buttongroup:
     _: shadow-small

--- a/tokens/tori.fi/buttongroup.yml
+++ b/tokens/tori.fi/buttongroup.yml
@@ -9,7 +9,7 @@ color:
         active: white
       background:
         _: white
-        hover: white
+        hover: petroleum-50
         active:
           _: petroleum-600
           hover: petroleum-600

--- a/tokens/tori.fi/buttongroup.yml
+++ b/tokens/tori.fi/buttongroup.yml
@@ -3,19 +3,34 @@ token: maps
 
 color:
   buttongroup:
-    text:
-      _: petroleum-600
-      active: white
-    background:
-      _: white
-      hover: white
-      active:
+    primary:
+      text:
         _: petroleum-600
+        active: white
+      background:
+        _: white
+        hover: white
+        active:
+          _: petroleum-600
+          hover: petroleum-600
+      border:
+        _: gray-300
         hover: petroleum-600
-    border:
-      _: gray-300
-      hover: gray-900
-      active: petroleum-600
+        active: petroleum-600
+    utility:
+      text:
+        _: gray-700
+        active: gray-700
+      background:
+        _: white
+        hover: gray-100
+        active:
+          _: gray-200
+          hover: gray-200
+      border:
+        _: gray-300
+        hover: gray-500
+        active: gray-700
 shadow:
   buttongroup:
     _: shadow-small


### PR DESCRIPTION
### Changes included:
- add tokens for utility variant of button group component based on button tokens
- add "primary" category to previous tokens
- change Tori colors:
--`color-buttongroup-primary-background-hover` to `petroleum-50`
--`color-buttongroup-primary-border-hover` to `petroleum-600`