### PR TITLE
fix: tokens for active hover state for buttongroup

### DIFF
--- a/tokens/blocket.se/buttongroup.yml
+++ b/tokens/blocket.se/buttongroup.yml
@@ -16,7 +16,9 @@ color:
       border:
         _: bluegray-300
         hover: blue-600
-        active: blue-600
+        active: 
+          _: blue-600
+          hover: blue-600
     utility:
       text:
         _: gray-700

--- a/tokens/blocket.se/buttongroup.yml
+++ b/tokens/blocket.se/buttongroup.yml
@@ -10,15 +10,11 @@ color:
       background:
         _: white
         hover: blue-50
-        active:
-          _: blue-600
-          hover: blue-700
+        active: blue-600
       border:
         _: bluegray-300
         hover: blue-600
-        active: 
-          _: blue-600
-          hover: blue-600
+        active: blue-600
     utility:
       text:
         _: gray-700
@@ -26,9 +22,7 @@ color:
       background:
         _: white
         hover: gray-100
-        active:
-          _: gray-200
-          hover: gray-200
+        active: gray-200
       border:
         _: gray-300
         hover: gray-500

--- a/tokens/blocket.se/buttongroup.yml
+++ b/tokens/blocket.se/buttongroup.yml
@@ -13,7 +13,6 @@ color:
         active: blue-600
       border:
         _: bluegray-300
-        hover: blue-600
         active: blue-600
     utility:
       text:
@@ -25,7 +24,6 @@ color:
         active: gray-200
       border:
         _: gray-300
-        hover: gray-500
         active: gray-700
 shadow:
   buttongroup:

--- a/tokens/finn.no/buttongroup.yml
+++ b/tokens/finn.no/buttongroup.yml
@@ -16,7 +16,9 @@ color:
       border:
         _: bluegray-300
         hover: blue-600
-        active: blue-600
+        active: 
+          _: blue-600
+          hover: blue-600
     utility:
       text:
         _: gray-700

--- a/tokens/finn.no/buttongroup.yml
+++ b/tokens/finn.no/buttongroup.yml
@@ -10,15 +10,11 @@ color:
       background:
         _: white
         hover: blue-50
-        active:
-          _: blue-600
-          hover: blue-700
+        active: blue-600
       border:
         _: bluegray-300
         hover: blue-600
-        active: 
-          _: blue-600
-          hover: blue-600
+        active: blue-600
     utility:
       text:
         _: gray-700
@@ -26,9 +22,7 @@ color:
       background:
         _: white
         hover: gray-100
-        active:
-          _: gray-200
-          hover: gray-200
+        active: gray-200
       border:
         _: gray-300
         hover: gray-500

--- a/tokens/finn.no/buttongroup.yml
+++ b/tokens/finn.no/buttongroup.yml
@@ -13,7 +13,6 @@ color:
         active: blue-600
       border:
         _: bluegray-300
-        hover: blue-600
         active: blue-600
     utility:
       text:
@@ -25,7 +24,6 @@ color:
         active: gray-200
       border:
         _: gray-300
-        hover: gray-500
         active: gray-700
 shadow:
   buttongroup:

--- a/tokens/tori.fi/buttongroup.yml
+++ b/tokens/tori.fi/buttongroup.yml
@@ -16,7 +16,9 @@ color:
       border:
         _: gray-300
         hover: petroleum-600
-        active: petroleum-600
+        active: 
+          _: petroleum-600
+          hover: petroleum-600
     utility:
       text:
         _: gray-700

--- a/tokens/tori.fi/buttongroup.yml
+++ b/tokens/tori.fi/buttongroup.yml
@@ -10,15 +10,11 @@ color:
       background:
         _: white
         hover: petroleum-50
-        active:
-          _: petroleum-600
-          hover: petroleum-600
+        active: petroleum-600
       border:
         _: gray-300
         hover: petroleum-600
-        active: 
-          _: petroleum-600
-          hover: petroleum-600
+        active: petroleum-600
     utility:
       text:
         _: gray-700
@@ -26,9 +22,7 @@ color:
       background:
         _: white
         hover: gray-100
-        active:
-          _: gray-200
-          hover: gray-200
+        active: gray-200
       border:
         _: gray-300
         hover: gray-500

--- a/tokens/tori.fi/buttongroup.yml
+++ b/tokens/tori.fi/buttongroup.yml
@@ -13,7 +13,6 @@ color:
         active: petroleum-600
       border:
         _: gray-300
-        hover: petroleum-600
         active: petroleum-600
     utility:
       text:
@@ -25,7 +24,6 @@ color:
         active: gray-200
       border:
         _: gray-300
-        hover: gray-500
         active: gray-700
 shadow:
   buttongroup:


### PR DESCRIPTION
Tokens for the active hover state can be removed. This was concluded by @adidick and will be removed from the Taxonomy sheet as well.