### PR TITLE
fix(typography): update typography tokens to use t-shirt sizes

### DIFF
--- a/tokens/blocket.se/typography.yml
+++ b/tokens/blocket.se/typography.yml
@@ -4,19 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    12: 12
-    14: 14
-    16: 16
-    18: 18
-    22: 22
-    28: 28
-    34: 34
+    xs: 12
+    s: 14
+    m: 16
+    ml: 20
+    l: 22
+    xl: 28
+    xxl: 34
+    xxxl: 48
 line:
   height:
-    16: 16
-    18: 18
-    22: 22
-    24: 24
-    28: 28
-    34: 34
-    41: 41
+    xs: 16
+    s: 18
+    m: 22
+    ml: 26
+    l: 28
+    xl: 34
+    xxl: 41
+    xxxl: 56

--- a/tokens/finn.no/typography.yml
+++ b/tokens/finn.no/typography.yml
@@ -4,19 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    12: 12
-    14: 14
-    16: 16
-    18: 18
-    22: 22
-    28: 28
-    34: 34
+    xs: 12
+    s: 14
+    m: 16
+    ml: 20
+    l: 22
+    xl: 28
+    xxl: 34
+    xxxl: 48
 line:
   height:
-    16: 16
-    18: 18
-    22: 22
-    24: 24
-    28: 28
-    34: 34
-    41: 41
+    xs: 16
+    s: 18
+    m: 22
+    ml: 26
+    l: 28
+    xl: 34
+    xxl: 41
+    xxxl: 56

--- a/tokens/tori.fi/typography.yml
+++ b/tokens/tori.fi/typography.yml
@@ -4,19 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    12: 12
-    14: 14
-    16: 16
-    18: 18
-    22: 22
-    28: 28
-    34: 34
+    xs: 12
+    s: 14
+    m: 16
+    ml: 20
+    l: 22
+    xl: 28
+    xxl: 34
+    xxxl: 48
 line:
   height:
-    16: 16
-    18: 18
-    22: 22
-    24: 24
-    28: 28
-    34: 34
-    41: 41
+    xs: 16
+    s: 18
+    m: 22
+    ml: 26
+    l: 28
+    xl: 34
+    xxl: 41
+    xxxl: 56


### PR DESCRIPTION
We will use t-shirt sizes in tokens. Those can be applied to utility classes that are based on either t-shirt sizes or numbers for now but the latter, i.e. the ones that are in the `text-14` format, will be deprecated eventually.