### PR TITLE
fix(typography): use rem values

### DIFF
--- a/tokens/blocket.se/typography.yml
+++ b/tokens/blocket.se/typography.yml
@@ -4,21 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    xs: 12
-    s: 14
-    m: 16
-    ml: 20
-    l: 22
-    xl: 28
-    xxl: 34
-    xxxl: 48
+    xs: 1.2rem
+    s: 1.4rem
+    m: 1.6rem
+    ml: 2rem
+    l: 2.2rem
+    xl: 2.8rem
+    xxl: 3.4rem
+    xxxl: 4.8rem
 line:
   height:
-    xs: 16
-    s: 18
-    m: 22
-    ml: 26
-    l: 28
-    xl: 34
-    xxl: 41
-    xxxl: 56
+    xs: 1.6rem
+    s: 1.8rem
+    m: 2.2rem
+    ml: 2.6rem
+    l: 2.8rem
+    xl: 3.4rem
+    xxl: 4.1rem
+    xxxl: 5.6rem

--- a/tokens/finn.no/typography.yml
+++ b/tokens/finn.no/typography.yml
@@ -4,21 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    xs: 12
-    s: 14
-    m: 16
-    ml: 20
-    l: 22
-    xl: 28
-    xxl: 34
-    xxxl: 48
+    xs: 1.2rem
+    s: 1.4rem
+    m: 1.6rem
+    ml: 2rem
+    l: 2.2rem
+    xl: 2.8rem
+    xxl: 3.4rem
+    xxxl: 4.8rem
 line:
   height:
-    xs: 16
-    s: 18
-    m: 22
-    ml: 26
-    l: 28
-    xl: 34
-    xxl: 41
-    xxxl: 56
+    xs: 1.6rem
+    s: 1.8rem
+    m: 2.2rem
+    ml: 2.6rem
+    l: 2.8rem
+    xl: 3.4rem
+    xxl: 4.1rem
+    xxxl: 5.6rem

--- a/tokens/tori.fi/typography.yml
+++ b/tokens/tori.fi/typography.yml
@@ -4,21 +4,21 @@ token: defs
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
-    xs: 12
-    s: 14
-    m: 16
-    ml: 20
-    l: 22
-    xl: 28
-    xxl: 34
-    xxxl: 48
+    xs: 1.2rem
+    s: 1.4rem
+    m: 1.6rem
+    ml: 2rem
+    l: 2.2rem
+    xl: 2.8rem
+    xxl: 3.4rem
+    xxxl: 4.8rem
 line:
   height:
-    xs: 16
-    s: 18
-    m: 22
-    ml: 26
-    l: 28
-    xl: 34
-    xxl: 41
-    xxxl: 56
+    xs: 1.6rem
+    s: 1.8rem
+    m: 2.2rem
+    ml: 2.6rem
+    l: 2.8rem
+    xl: 3.4rem
+    xxl: 4.1rem
+    xxxl: 5.6rem


### PR DESCRIPTION
## Description
Define typography tokens with rem values, and not just numbers, making it easier to apply them to typography rules in https://github.com/warp-ds/drive/blob/typography/src/_rules/typography.js

## Background
Together with @Skadefryd we used some time in [@warp-ds/drive](https://github.com/warp-ds/drive/blob/typography/src/_rules/typography.js) trying to apply different units (px/rem) to the font-size/line-height CSS variables coming from this repo, and the only way to do that was to use a [calc()](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function, like this:
```
const remifyVar = (cssVar) => {
    if (opts.usePixels) {
      return `calc(${cssVar} * 1px)`;
    }

    return `calc(${divideByTen(cssVar)} * 1rem)`;
  };
```
We think that this is not optimal and makes the generated css unnecessarily complicated and possibly error-prone. 

Then we considered having two tokens per each font size and line height, which would be defined with `px` and `rem` values respectively. 
And that lead us to a conclusion that maybe it's actually the right moment to claim that font sizes and line heights should not be applied using pixels at all.