### PR TITLE
feat(base.yml): add decoration-text-link and font-family tokens

### DIFF
--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -12,6 +12,7 @@ font:
     xl: 2.8rem
     xxl: 3.4rem
     xxxl: 4.8rem
+  family: 'BlocketSans-Regular, sans-serif'
 line:
   height:
     xs: 1.6rem
@@ -26,6 +27,3 @@ line:
 decoration:
   text:
     link: underline
-
-font:
-  family: 'BlocketSans-Regular, sans-serif'

--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -28,4 +28,4 @@ decoration:
     link: underline
 
 font:
-  family: BlocketSans-Regular, sans-serif
+  family: 'BlocketSans-Regular, sans-serif'

--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -22,3 +22,10 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
+
+decoration:
+  text:
+    link: underline
+
+font:
+  family: BlocketSans-Regular, sans-serif

--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -15,14 +15,14 @@ font:
   family: 'BlocketSans-Regular, sans-serif'
 line:
   height:
-    xs: 1.6rem
-    s: 1.8rem
-    m: 2.2rem
-    ml: 2.6rem
-    l: 2.8rem
-    xl: 3.4rem
-    xxl: 4.1rem
-    xxxl: 5.6rem
+    xs: 1.6
+    s: 1.8
+    m: 2.2
+    ml: 2.6
+    l: 2.8
+    xl: 3.4
+    xxl: 4.1
+    xxxl: 5.6
 
 decoration:
   text:

--- a/tokens/finn.no/base.yml
+++ b/tokens/finn.no/base.yml
@@ -1,6 +1,8 @@
 ---
 token: defs
 
+# TODO: font-size, line-height, shadows, colors and all other common things should live in a common.css rather than brand.css.
+
 # values are in pixels but they render by default as rems. Using `usePixels=true` flag in @warp-ds/uno forces them to pixels.
 font:
   size:
@@ -22,3 +24,10 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
+
+decoration:
+  text:
+    link: underline
+
+font:
+  family: 'Finntype'

--- a/tokens/finn.no/base.yml
+++ b/tokens/finn.no/base.yml
@@ -14,6 +14,7 @@ font:
     xl: 2.8rem
     xxl: 3.4rem
     xxxl: 4.8rem
+  family: 'Finntype'
 line:
   height:
     xs: 1.6rem
@@ -28,6 +29,3 @@ line:
 decoration:
   text:
     link: underline
-
-font:
-  family: 'Finntype'

--- a/tokens/finn.no/base.yml
+++ b/tokens/finn.no/base.yml
@@ -17,14 +17,14 @@ font:
   family: 'Finntype'
 line:
   height:
-    xs: 1.6rem
-    s: 1.8rem
-    m: 2.2rem
-    ml: 2.6rem
-    l: 2.8rem
-    xl: 3.4rem
-    xxl: 4.1rem
-    xxxl: 5.6rem
+    xs: 1.6
+    s: 1.8
+    m: 2.2
+    ml: 2.6
+    l: 2.8
+    xl: 3.4
+    xxl: 4.1
+    xxxl: 5.6
 
 decoration:
   text:

--- a/tokens/tori.fi/base.yml
+++ b/tokens/tori.fi/base.yml
@@ -12,6 +12,7 @@ font:
     xl: 2.8rem
     xxl: 3.4rem
     xxxl: 4.8rem
+  family: 'Open Sans'
 line:
   height:
     xs: 1.6rem
@@ -26,6 +27,3 @@ line:
 decoration:
   text:
     link: none
-
-font:
-  family: 'Open Sans'

--- a/tokens/tori.fi/base.yml
+++ b/tokens/tori.fi/base.yml
@@ -22,3 +22,10 @@ line:
     xl: 3.4rem
     xxl: 4.1rem
     xxxl: 5.6rem
+
+decoration:
+  text:
+    link: none
+
+font:
+  family: 'Open Sans'

--- a/tokens/tori.fi/base.yml
+++ b/tokens/tori.fi/base.yml
@@ -15,14 +15,14 @@ font:
   family: 'Open Sans'
 line:
   height:
-    xs: 1.6rem
-    s: 1.8rem
-    m: 2.2rem
-    ml: 2.6rem
-    l: 2.8rem
-    xl: 3.4rem
-    xxl: 4.1rem
-    xxxl: 5.6rem
+    xs: 1.6
+    s: 1.8
+    m: 2.2
+    ml: 2.6
+    l: 2.8
+    xl: 3.4
+    xxl: 4.1
+    xxxl: 5.6
 
 decoration:
   text:


### PR DESCRIPTION
Changes included:
- add `decoration-text-link` and `font-family` tokens
- rename `typography.yml` file to `base.yml` as it now includes tokens for a future base.css file that would be common to all brands
- remove units from line-height values