### PR TITLE
feat: add fonts import

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function process(tld) {
   const tokens = tokenize(`./tokens/${tld}`);
   const css = minify(tokens);
   const filename = path.join(outPath, slugify(tld)) + '.css';
-  fs.writeFileSync(filename, css, 'utf-8');
+  const fontsImport = `@import'https://assets.finn.no/pkg/@warp-ds/css/v1/fonts/${path.basename(filename)}';`
+  fs.writeFileSync(filename, `${fontsImport}${css}`, 'utf-8');
 }
 
 process('finn.no')

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function process(tld) {
   const tokens = tokenize(`./tokens/${tld}`);
   const css = minify(tokens);
   const filename = path.join(outPath, slugify(tld)) + '.css';
-  const fontsImport = `@import'https://assets.finn.no/pkg/@warp-ds/css/v1/fonts/${path.basename(filename)}';`
+  const fontsImport = `@import'https://assets.finn.no/pkg/@warp-ds/fonts/v1/${path.basename(filename)}';`
   fs.writeFileSync(filename, `${fontsImport}${css}`, 'utf-8');
 }
 

--- a/tokens/tori.fi/base.yml
+++ b/tokens/tori.fi/base.yml
@@ -12,7 +12,7 @@ font:
     xl: 2.8rem
     xxl: 3.4rem
     xxxl: 4.8rem
-  family: 'Open Sans'
+  family: 'ToriSans, sans-serif'
 line:
   height:
     xs: 1.6rem


### PR DESCRIPTION
Font declarations should be part of the brand.css files.
Fonts and font setup files are published to Eik CDN from https://github.com/warp-ds/fonts.