### PR TITLE
fix: rename font-family token to BlocketSans to align with fonts repo

### DIFF
--- a/tokens/blocket.se/base.yml
+++ b/tokens/blocket.se/base.yml
@@ -12,7 +12,7 @@ font:
     xl: 2.8rem
     xxl: 3.4rem
     xxxl: 4.8rem
-  family: 'BlocketSans-Regular, sans-serif'
+  family: 'BlocketSans, sans-serif'
 line:
   height:
     xs: 1.6rem


### PR DESCRIPTION
There might be changes to blocket fonts setup eventually but for now in order for them to work we have to rename the font-family to what it was called in @warp-ds/fonts repo: https://github.com/warp-ds/fonts/blob/main/blocket/blocket-se.css