### PR TITLE
fix: Remove any ending "-default" from all semantic token names

### DIFF
--- a/tokens/blocket.se/semantic.yml
+++ b/tokens/blocket.se/semantic.yml
@@ -5,127 +5,127 @@ s:
   color:
 
     background:
-      default: white
+      _: white
       hover: bluegray-100
       active:
         _: blue-50
         hover: blue-100
       disabled: bluegray-300
       subtle:
-        default: bluegray-50
+        _: bluegray-50
         hover: bluegray-100
         active:
           _: bluegray-100
           hover: bluegray-200
         disabled: bluegray-300
       primary:
-        default: blue-600
+        _: blue-600
         hover: blue-700
         active:
           _: blue-800
           hover: blue-700
       positive:
-        default: green-50
+        _: green-50
         hover: green-100
         active:
           _: green-100
           hover: green-200
       negative:
-        default: red-50
+        _: red-50
         hover: red-100
         active:
           _: red-50
           hover: red-100
       warning:
-        default: yellow-50
+        _: yellow-50
         hover: yellow-100
         active:
           _: yellow-50
           hover: yellow-100
       info:
-        default: aqua-50
+        _: aqua-50
         hover: aqua-100
         active:
           _: aqua-50
           hover: aqua-100
 
     border:
-      default: bluegray-300
+      _: bluegray-300
       hover: gray-500
       active:
         _: gray-700
         hover: gray-800
       disabled: bluegray-300
       primary:
-        default: blue-600
+        _: blue-600
         hover: blue-700
         active:
           _: blue-800
           hover: blue-700
         subtle:
-          default: blue-300
+          _: blue-300
           hover: blue-400
           active:
             _: blue-600
             hover: blue-700
       positive:
-        default: green-600
+        _: green-600
         hover: green-700
         active:
           _: green-600
           hover: green-700
         subtle:
-          default: green-300
+          _: green-300
           hover: green-400
           active:
             _: green-600
             hover: green-700
       negative:
-        default: red-600
+        _: red-600
         hover: red-700
         active:
           _: red-600
           hover: red-700
         subtle:
-          default: red-300
+          _: red-300
           hover: red-400
           active:
             _: red-600
             hover: red-700
       warning:
-        default: yellow-600
+        _: yellow-600
         hover: yellow-700
         active:
           _: yellow-600
           hover: yellow-700
         subtle:
-          default: yellow-300
+          _: yellow-300
           hover: yellow-400
           active:
             _: yellow-600
             hover: yellow-700
       info:
-        default: aqua-600
+        _: aqua-600
         hover: aqua-700
         active:
           _: aqua-600
           hover: aqua-700
         subtle:
-          default: aqua-300
+          _: aqua-300
           hover: aqua-400
           active:
             _: aqua-600
             hover: aqua-700
 
     icon:
-      default: gray-500
+      _: gray-500
       hover: gray-600
       active:
         _: blue-600
         hover: gray-600
       disabled: bluegray-300
       subtle:
-        default: bluegray-500
+        _: bluegray-500
         hover: bluegray-600
         active:
           _: blue-600
@@ -138,7 +138,7 @@ s:
       info: aqua-600
 
     text:
-      default: gray-700
+      _: gray-700
       subtle: gray-500
       placeholder: bluegray-300
       inverted:
@@ -151,5 +151,3 @@ s:
         disabled: bluegray-300
       negative: red-600
       positive: green-600
-
-

--- a/tokens/finn.no/semantic.yml
+++ b/tokens/finn.no/semantic.yml
@@ -5,127 +5,127 @@ s:
   color:
 
     background:
-      default: white
+      _: white
       hover: bluegray-100
       active:
         _: blue-50
         hover: blue-100
       disabled: bluegray-300
       subtle:
-        default: bluegray-50
+        _: bluegray-50
         hover: bluegray-100
         active:
           _: bluegray-100
           hover: bluegray-200
         disabled: bluegray-300
       primary:
-        default: blue-600
+        _: blue-600
         hover: blue-700
         active:
           _: blue-800
           hover: blue-700
       positive:
-        default: green-50
+        _: green-50
         hover: green-100
         active:
           _: green-100
           hover: green-200
       negative:
-        default: red-50
+        _: red-50
         hover: red-100
         active:
           _: red-50
           hover: red-100
       warning:
-        default: yellow-50
+        _: yellow-50
         hover: yellow-100
         active:
           _: yellow-50
           hover: yellow-100
       info:
-        default: aqua-50
+        _: aqua-50
         hover: aqua-100
         active:
           _: aqua-50
           hover: aqua-100
 
     border:
-      default: bluegray-300
+      _: bluegray-300
       hover: gray-500
       active:
         _: gray-700
         hover: gray-800
       disabled: bluegray-300
       primary:
-        default: blue-600
+        _: blue-600
         hover: blue-700
         active:
           _: blue-800
           hover: blue-700
         subtle:
-          default: blue-300
+          _: blue-300
           hover: blue-400
           active:
             _: blue-600
             hover: blue-700
       positive:
-        default: green-600
+        _: green-600
         hover: green-700
         active:
           _: green-600
           hover: green-700
         subtle:
-          default: green-300
+          _: green-300
           hover: green-400
           active:
             _: green-600
             hover: green-700
       negative:
-        default: red-600
+        _: red-600
         hover: red-700
         active:
           _: red-600
           hover: red-700
         subtle:
-          default: red-300
+          _: red-300
           hover: red-400
           active:
             _: red-600
             hover: red-700
       warning:
-        default: yellow-600
+        _: yellow-600
         hover: yellow-700
         active:
           _: yellow-600
           hover: yellow-700
         subtle:
-          default: yellow-300
+          _: yellow-300
           hover: yellow-400
           active:
             _: yellow-600
             hover: yellow-700
       info:
-        default: aqua-600
+        _: aqua-600
         hover: aqua-700
         active:
           _: aqua-600
           hover: aqua-700
         subtle:
-          default: aqua-300
+          _: aqua-300
           hover: aqua-400
           active:
             _: aqua-600
             hover: aqua-700
 
     icon:
-      default: gray-500
+      _: gray-500
       hover: gray-600
       active:
         _: blue-600
         hover: gray-600
       disabled: bluegray-300
       subtle:
-        default: bluegray-500
+        _: bluegray-500
         hover: bluegray-600
         active:
           _: blue-600
@@ -138,7 +138,7 @@ s:
       info: aqua-600
 
     text:
-      default: gray-700
+      _: gray-700
       subtle: gray-500
       placeholder: bluegray-300
       inverted:
@@ -151,5 +151,3 @@ s:
         disabled: bluegray-300
       negative: red-600
       positive: green-600
-
-

--- a/tokens/tori.fi/semantic.yml
+++ b/tokens/tori.fi/semantic.yml
@@ -5,127 +5,127 @@ s:
   color:
 
     background:
-      default: white
+      _: white
       hover: gray-100
       active:
         _: petroleum-50
         hover: petroleum-100
       disabled: gray-300
       subtle:
-        default: gray-50
+        _: gray-50
         hover: gray-100
         active:
           _: gray-100
           hover: gray-200
         disabled: gray-300
       primary:
-        default: watermelon-600
+        _: watermelon-600
         hover: watermelon-700
         active:
           _: watermelon-800
           hover: watermelon-700
       positive:
-        default: green-50
+        _: green-50
         hover: green-100
         active:
           _: green-100
           hover: green-200
       negative:
-        default: red-50
+        _: red-50
         hover: red-100
         active:
           _: red-50
           hover: red-100
       warning:
-        default: yellow-50
+        _: yellow-50
         hover: yellow-100
         active:
           _: yellow-50
           hover: yellow-100
       info:
-        default: petroleum-50
+        _: petroleum-50
         hover: petroleum-100
         active:
           _: petroleum-50
           hover: petroleum-100
 
     border:
-      default: gray-300
+      _: gray-300
       hover: gray-500
       active:
         _: gray-700
         hover: gray-800
       disabled: gray-300
       primary:
-        default: watermelon-600
+        _: watermelon-600
         hover: watermelon-700
         active:
           _: watermelon-800
           hover: watermelon-700
         subtle:
-          default: watermelon-300
+          _: watermelon-300
           hover: watermelon-400
           active:
             _: watermelon-600
             hover: watermelon-700
       positive:
-        default: green-600
+        _: green-600
         hover: green-700
         active:
           _: green-600
           hover: green-700
         subtle:
-          default: green-300
+          _: green-300
           hover: green-400
           active:
             _: green-600
             hover: green-700
       negative:
-        default: red-600
+        _: red-600
         hover: red-700
         active:
           _: red-600
           hover: red-700
         subtle:
-          default: red-300
+          _: red-300
           hover: red-400
           active:
             _: red-600
             hover: red-700
       warning:
-        default: yellow-600
+        _: yellow-600
         hover: yellow-700
         active:
           _: yellow-600
           hover: yellow-700
         subtle:
-          default: yellow-300
+          _: yellow-300
           hover: yellow-400
           active:
             _: yellow-600
             hover: yellow-700
       info:
-        default: petroleum-600
+        _: petroleum-600
         hover: petroleum-700
         active:
           _: petroleum-600
           hover: petroleum-700
         subtle:
-          default: petroleum-300
+          _: petroleum-300
           hover: petroleum-400
           active:
             _: petroleum-600
             hover: petroleum-700
 
     icon:
-      default: gray-500
+      _: gray-500
       hover: gray-600
       active:
         _: watermelon-600
         hover: gray-600
       disabled: gray-300
       subtle:
-        default: gray-500
+        _: gray-500
         hover: gray-600
         active:
           _: petroleum-600
@@ -138,7 +138,7 @@ s:
       info: petroleum-600
 
     text:
-      default: gray-900
+      _: gray-900
       subtle: gray-500
       placeholder: gray-300
       inverted:


### PR DESCRIPTION
To shorten and to align the naming of the tokens, any ending "-default" in semantic token names is now stripped.

This will result in shorter and more predictable semantic classes (e.g `s-bg-default, s-bg-positive-default, s-text-default` will now be `s-bg, s-bg-positive, s-text`).

For the base layer token names (i.e. s-bg, s-text, s-border, s-icon) to work without ending "default" suffix, this update: https://github.com/warp-ds/drive/pull/133 is required in [@warp-ds/uno](https://github.com/warp-ds/drive)