### PR TITLE
fix: Add misc missing component tokens

### DIFF
--- a/tokens/blocket.se/buttons.yml
+++ b/tokens/blocket.se/buttons.yml
@@ -60,6 +60,8 @@ color:
         text: bluegray-300
         border: bluegray-300
       background: bluegray-300
+    link:
+      text: s-color-text-link
     favorite:
       background:
         _: transparent

--- a/tokens/blocket.se/combobox.yml
+++ b/tokens/blocket.se/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/blocket.se/input.yml
+++ b/tokens/blocket.se/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: bluegray-300
       active: gray-700
       filled: gray-700

--- a/tokens/blocket.se/switch.yml
+++ b/tokens/blocket.se/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: bluegray-300
+shadow:
+  switch:
+    handle: shadow-s

--- a/tokens/finn.no/buttons.yml
+++ b/tokens/finn.no/buttons.yml
@@ -60,6 +60,8 @@ color:
       quiet:
         text: bluegray-300
         border: bluegray-300
+    link:
+      text: s-color-text-link
     pill:
       background:
         _: transparent

--- a/tokens/finn.no/combobox.yml
+++ b/tokens/finn.no/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/finn.no/input.yml
+++ b/tokens/finn.no/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: bluegray-300
       active: gray-700
       filled: gray-700

--- a/tokens/finn.no/switch.yml
+++ b/tokens/finn.no/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: bluegray-300
+shadow:
+  switch:
+    handle: shadow-s

--- a/tokens/tori.fi/buttons.yml
+++ b/tokens/tori.fi/buttons.yml
@@ -60,6 +60,8 @@ color:
       quiet:
         text: gray-300
         border: gray-300
+    link:
+      text: s-color-text-link
     pill:
       background:
         _: transparent

--- a/tokens/tori.fi/combobox.yml
+++ b/tokens/tori.fi/combobox.yml
@@ -1,0 +1,14 @@
+---
+token: maps
+
+color:
+  combobox:
+    background: s-color-background-default
+    option:
+      background:
+        hover: s-color-background-hover
+        selected:
+          _: s-color-background-active
+          hover: s-color-background-active-hover
+shadow:
+  combobox: shadow-m

--- a/tokens/tori.fi/input.yml
+++ b/tokens/tori.fi/input.yml
@@ -4,6 +4,7 @@ token: maps
 color:
   input:
     text:
+      placeholder: s-color-text-placeholder
       hint: gray-300
       active: gray-700
       filled: gray-700

--- a/tokens/tori.fi/switch.yml
+++ b/tokens/tori.fi/switch.yml
@@ -15,3 +15,6 @@ color:
       background:
         _: white
         disabled: gray-300
+shadow:
+  switch:
+    handle: shadow-s


### PR DESCRIPTION
This will just add new component tokens that is needed to clean-up the component-classes repo from direct use of semantic tokens in this PR: https://github.com/warp-ds/component-classes/pull/100